### PR TITLE
Custom error response code 502. Connectivity logs update. Ping commands at top for easy at-a-glance debugging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
       TIMESTAMP_IN_UTC [#2::UNIQUE_IDENTIFIER] [Tool Request - Retries Left: 1] [INFO] POST http://<URL>/wd/hub/status, {"method":"POST","headers":{".......","Proxy-Authorization":"Basic AaBbCcDdEeFfGg==","X-Requests-Debugger":"2::UNIQUE_IDENTIFIER"},"host":"<EXTERNAL_PROXY_URL>","port":"3130","path":"http://<URL>/wd/hub/status","data":"{\"key\": \"value\"}"}
       TIMESTAMP_IN_UTC [#2::UNIQUE_IDENTIFIER] [Tool Request - Retries Left: 1] [ERROR] POST http://<URL>/wd/hub/status, {"errorMessage":"Error: getaddrinfo ENOTFOUND <EXTERNAL_PROXY_URL> <EXTERNAL_PROXY_URL>:3130"}
       TIMESTAMP_IN_UTC [#2::UNIQUE_IDENTIFIER] [Tool Request - Retries Left: 0] [ERROR] POST http://<URL>/wd/hub/status, {"errorMessage":"Error: getaddrinfo ENOTFOUND <EXTERNAL_PROXY_URL> <EXTERNAL_PROXY_URL>:3130"}
-      TIMESTAMP_IN_UTC [#2::UNIQUE_IDENTIFIER] [Response End] [ERROR] POST http://<URL>/wd/hub/status, Status Code: 500, {"message":"Error: getaddrinfo ENOTFOUND <EXTERNAL_PROXY_URL> <EXTERNAL_PROXY_URL>:3130. Request Failed At Requests Debugger","error":"Request Failed At Requests Debugger"}
+      TIMESTAMP_IN_UTC [#2::UNIQUE_IDENTIFIER] [Response End] [ERROR] POST http://<URL>/wd/hub/status, Status Code: 502, {"message":"Error: getaddrinfo ENOTFOUND <EXTERNAL_PROXY_URL> <EXTERNAL_PROXY_URL>:3130. Request Failed At Requests Debugger","error":"Request Failed At Requests Debugger"}
   - Tags & their meaning:
     - **TIMESTAMP_IN_UTC** : Timestamp of each event in UTC.
     - **#2** : This represents the `nth` request which the tool served from the time it was started.

--- a/config/constants.js
+++ b/config/constants.js
@@ -3,6 +3,7 @@ module.exports.HUB_STATUS_URL = 'http://hub-cloud.browserstack.com/wd/hub/status
 module.exports.RAILS_AUTOMATE = 'http://automate.browserstack.com';
 module.exports.CONNECTIVITY_REQ_TIMEOUT = 30000;
 module.exports.DEFAULT_PROXY_PORT = 3128;
+module.exports.CUSTOM_ERROR_RESPONSE_CODE = 502;
 module.exports.MAX_RETRIES = 1;
 module.exports.LOGS_FOLDER = 'RequestsDebuggerLogs';
 module.exports.PORTS = {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   "bin": {
     "RequestsDebugger": "src/requestsDebugger.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/browserstack/requests-debugger.git"
+  },
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/src/connectivity.js
+++ b/src/connectivity.js
@@ -71,7 +71,7 @@ var ConnectivityChecker = {
   httpToHubWithoutProxy: function (callback) {
     var requestUrl = constants.HUB_STATUS_URL;
     var requestOptions = ConnectivityChecker.reqOpsWithoutProxy(requestUrl, 'http');
-    fireRequest(requestOptions, 'http', 'HTTP Request To Hub Without Proxy', [200], function (response) {
+    fireRequest(requestOptions, 'http', 'HTTP Request To ' + requestUrl + ' Without Proxy', [200], function (response) {
       callback(response);
     });
   },
@@ -79,7 +79,7 @@ var ConnectivityChecker = {
   httpToRailsWithoutProxy: function (callback) {
     var requestUrl = constants.RAILS_AUTOMATE;
     var requestOptions = ConnectivityChecker.reqOpsWithoutProxy(requestUrl, 'http');
-    fireRequest(requestOptions, 'http', 'HTTP Request To Rails Without Proxy', [200, 301], function (response) {
+    fireRequest(requestOptions, 'http', 'HTTP Request To ' + requestUrl + ' Without Proxy', [200, 301], function (response) {
       callback(response);
     });
   },
@@ -87,7 +87,7 @@ var ConnectivityChecker = {
   httpsToHubWithoutProxy: function (callback) {
     var requestUrl = constants.HUB_STATUS_URL;
     var requestOptions = ConnectivityChecker.reqOpsWithoutProxy(requestUrl, 'https');
-    fireRequest(requestOptions, 'https', 'HTTPS Request To Hub Without Proxy', [200], function (response) {
+    fireRequest(requestOptions, 'https', 'HTTPS Request To ' + requestUrl + ' Without Proxy', [200], function (response) {
       callback(response);
     });
   },
@@ -95,7 +95,7 @@ var ConnectivityChecker = {
   httpsToRailsWithoutProxy: function (callback) {
     var requestUrl = constants.RAILS_AUTOMATE;
     var requestOptions = ConnectivityChecker.reqOpsWithoutProxy(requestUrl, 'https');
-    fireRequest(requestOptions, 'https', 'HTTPS Request to Rails Without Proxy', [301, 302], function (response) {
+    fireRequest(requestOptions, 'https', 'HTTPS Request to ' + requestUrl + ' Without Proxy', [301, 302], function (response) {
       callback(response);
     });
   },
@@ -103,7 +103,7 @@ var ConnectivityChecker = {
   httpToHubWithProxy: function (callback) {
     var requestUrl = constants.HUB_STATUS_URL;
     var requestOptions = ConnectivityChecker.reqOpsWithProxy(requestUrl, 'http');
-    fireRequest(requestOptions, 'http', 'HTTP Request To Hub With Proxy', [200], function (response) {
+    fireRequest(requestOptions, 'http', 'HTTP Request To ' + requestUrl + ' With Proxy', [200], function (response) {
       callback(response);
     });
   },
@@ -111,7 +111,7 @@ var ConnectivityChecker = {
   httpToRailsWithProxy: function (callback) {
     var requestUrl = constants.RAILS_AUTOMATE;
     var requestOptions = ConnectivityChecker.reqOpsWithProxy(requestUrl, 'http');
-    fireRequest(requestOptions, 'http', 'HTTP Request To Rails With Proxy', [301], function (response) {
+    fireRequest(requestOptions, 'http', 'HTTP Request To ' + requestUrl + ' With Proxy', [301], function (response) {
       callback(response);
     });
   },

--- a/src/server.js
+++ b/src/server.js
@@ -99,7 +99,7 @@ var RdHandler = {
           },
           state: 'error'
         },
-        statusCode: 500
+        statusCode: constants.CUSTOM_ERROR_RESPONSE_CODE
       };
     } else {
       return {
@@ -107,7 +107,7 @@ var RdHandler = {
           message: errorMessage,
           error: constants.STATIC_MESSAGES.REQ_FAILED_MSG
         },
-        statusCode: 500
+        statusCode: constants.CUSTOM_ERROR_RESPONSE_CODE
       };
     }
   },

--- a/src/stats/linuxStats.js
+++ b/src/stats/linuxStats.js
@@ -61,7 +61,7 @@ LinuxStats.mem = function (callback) {
 
 LinuxStats.network = function (callback) {
   var startTime = new Date();
-  var commands = [constants.LINUX.TCP_LISTEN_ESTABLISHED, constants.COMMON.PING_HUB, constants.COMMON.PING_AUTOMATE];
+  var commands = [constants.COMMON.PING_HUB, constants.COMMON.PING_AUTOMATE, constants.LINUX.TCP_LISTEN_ESTABLISHED];
   var finalOutput = "";
 
   Utils.execMultiple(commands, function (results) {

--- a/src/stats/macStats.js
+++ b/src/stats/macStats.js
@@ -71,7 +71,7 @@ MacStats.mem = function (callback) {
 
 MacStats.network = function (callback) {
   var startTime = new Date();
-  var commands = [constants.MAC.TCP_LISTEN_ESTABLISHED, constants.COMMON.PING_HUB, constants.COMMON.PING_AUTOMATE];
+  var commands = [constants.COMMON.PING_HUB, constants.COMMON.PING_AUTOMATE, constants.MAC.TCP_LISTEN_ESTABLISHED];
   var finalOutput = "";
 
   Utils.execMultiple(commands, function (results) {

--- a/src/stats/winStats.js
+++ b/src/stats/winStats.js
@@ -66,7 +66,7 @@ WinStats.mem = function (callback) {
 
 WinStats.network = function (callback) {
   var startTime = new Date();
-  var commands = [constants.WIN.NETSTAT_TCP, constants.WIN.NETSTAT_ROUTING_TABLE, constants.WIN.IPCONFIG_ALL, constants.WIN.PING_HUB, constants.WIN.PING_AUTOMATE];
+  var commands = [constants.WIN.PING_HUB, constants.WIN.PING_AUTOMATE, constants.WIN.NETSTAT_TCP, constants.WIN.NETSTAT_ROUTING_TABLE, constants.WIN.IPCONFIG_ALL];
   var finalOutput = "";
 
   Utils.execMultiple(commands, function (results) {

--- a/test/connectivity.test.js
+++ b/test/connectivity.test.js
@@ -20,25 +20,25 @@ describe('Connectivity Checker for BrowserStack Components', function () {
     data: '{"data":"value"}',
     statusCode: 200,
     errorMessage: null,
-    description: 'HTTP Request To Hub Without Proxy',
+    description: 'HTTP Request To ' + constants.HUB_STATUS_URL + ' Without Proxy',
     result: 'Passed'
   }, {
     data: '{"data":"value"}',
     statusCode: 301,
     errorMessage: null,
-    description: 'HTTP Request To Rails Without Proxy',
+    description: 'HTTP Request To ' + constants.RAILS_AUTOMATE + ' Without Proxy',
     result: 'Passed'
   }, {
     data: '{"data":"value"}',
     statusCode: 200,
     errorMessage: null,
-    description: 'HTTPS Request To Hub Without Proxy',
+    description: 'HTTPS Request To ' + constants.HUB_STATUS_URL + ' Without Proxy',
     result: 'Passed'
   }, {
     data: '{"data":"value"}',
     statusCode: 302,
     errorMessage: null,
-    description: 'HTTPS Request to Rails Without Proxy',
+    description: 'HTTPS Request to ' + constants.RAILS_AUTOMATE + ' Without Proxy',
     result: 'Passed'
   }];
 
@@ -46,25 +46,25 @@ describe('Connectivity Checker for BrowserStack Components', function () {
     data: [],
     statusCode: null,
     errorMessage: 'Error: something terrible',
-    description: 'HTTP Request To Hub Without Proxy',
+    description: 'HTTP Request To ' + constants.HUB_STATUS_URL + ' Without Proxy',
     result: 'Failed'
   }, {
     data: [],
     statusCode: null,
     errorMessage: 'Error: something terrible',
-    description: 'HTTP Request To Rails Without Proxy',
+    description: 'HTTP Request To ' + constants.RAILS_AUTOMATE + ' Without Proxy',
     result: 'Failed'
   }, {
     data: [],
     statusCode: null,
     errorMessage: 'Error: something terrible',
-    description: 'HTTPS Request To Hub Without Proxy',
+    description: 'HTTPS Request To ' + constants.HUB_STATUS_URL + ' Without Proxy',
     result: 'Failed'
   }, {
     data: [],
     statusCode: null,
     errorMessage: 'Error: something terrible',
-    description: 'HTTPS Request to Rails Without Proxy',
+    description: 'HTTPS Request to ' + constants.RAILS_AUTOMATE + ' Without Proxy',
     result: 'Failed'
   }];
 
@@ -116,13 +116,13 @@ describe('Connectivity Checker for BrowserStack Components', function () {
       sinon.stub(Utils, 'beautifyObject');
       var resultWithProxy = resultWithoutProxy.concat([{
         data: '{"data":"value"}',
-        description: "HTTP Request To Hub With Proxy",
+        description: "HTTP Request To " + constants.HUB_STATUS_URL + " With Proxy",
         errorMessage: null,
         result: "Passed",
         statusCode: 200
       }, {
         data: '{"data":"value"}',
-        description: "HTTP Request To Rails With Proxy",
+        description: "HTTP Request To " + constants.RAILS_AUTOMATE + " With Proxy",
         errorMessage: null,
         result: "Passed",
         statusCode: 301


### PR DESCRIPTION
connectivity log changes : showing URL instead of the names of BrowserStack components
Custom error response code changed to 502 from 500.