### PR TITLE
Remove any protocol part from --proxy-host

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -10,6 +10,7 @@ module.exports.PORTS = {
   MAX: 65535,
   MIN: 1
 };
+module.exports.PROTOCOL_REGEX = /(^\w+:|^)\/\//;
 
 module.exports.LOGS = Object.freeze({
   NETWORK: 'NetworkStats.log',

--- a/src/commandLine.js
+++ b/src/commandLine.js
@@ -119,8 +119,13 @@ var CommandLineManager = {
     index = argv.indexOf('--proxy-host');
     if (index !== -1) {
       if (CommandLineManager.validArgValue(argv[index + 1])) {
+        var hostRegex = /(^\w+:|^)\/\//;
+        var host = argv[index + 1];
+        if (host.match(hostRegex)) {
+          host = host.replace(/(^\w+:|^)\/\//, '');
+        }
         RdGlobalConfig.proxy = RdGlobalConfig.proxy || {};
-        RdGlobalConfig.proxy.host = argv[index + 1];
+        RdGlobalConfig.proxy.host = host;
         argv.splice(index, 2);
       } else {
         invalidArgs.add('--proxy-host');

--- a/src/commandLine.js
+++ b/src/commandLine.js
@@ -123,7 +123,6 @@ var CommandLineManager = {
         if (host.match(constants.PROTOCOL_REGEX)) {
           host = host.replace(constants.PROTOCOL_REGEX, '');
         }
-        console.log(host);
         RdGlobalConfig.proxy = RdGlobalConfig.proxy || {};
         RdGlobalConfig.proxy.host = host;
         argv.splice(index, 2);

--- a/src/commandLine.js
+++ b/src/commandLine.js
@@ -119,11 +119,11 @@ var CommandLineManager = {
     index = argv.indexOf('--proxy-host');
     if (index !== -1) {
       if (CommandLineManager.validArgValue(argv[index + 1])) {
-        var hostRegex = /(^\w+:|^)\/\//;
         var host = argv[index + 1];
-        if (host.match(hostRegex)) {
-          host = host.replace(/(^\w+:|^)\/\//, '');
+        if (host.match(constants.PROTOCOL_REGEX)) {
+          host = host.replace(constants.PROTOCOL_REGEX, '');
         }
+        console.log(host);
         RdGlobalConfig.proxy = RdGlobalConfig.proxy || {};
         RdGlobalConfig.proxy.host = host;
         argv.splice(index, 2);

--- a/src/commandLine.js
+++ b/src/commandLine.js
@@ -120,9 +120,7 @@ var CommandLineManager = {
     if (index !== -1) {
       if (CommandLineManager.validArgValue(argv[index + 1])) {
         var host = argv[index + 1];
-        if (host.match(constants.PROTOCOL_REGEX)) {
-          host = host.replace(constants.PROTOCOL_REGEX, '');
-        }
+        host = host.replace(constants.PROTOCOL_REGEX, '');
         RdGlobalConfig.proxy = RdGlobalConfig.proxy || {};
         RdGlobalConfig.proxy.host = host;
         argv.splice(index, 2);

--- a/test/commandLine.test.js
+++ b/test/commandLine.test.js
@@ -31,7 +31,7 @@ describe('CommandLineManager', function () {
 
     it('parse proxy-host and proxy-port params', function () {
       sinon.stub(console, 'log');
-      argv = argv.concat(['--proxy-host', 'host', '--proxy-port', '9687']);
+      argv = argv.concat(['--proxy-host', 'http://host', '--proxy-port', '9687']);
       CommandLineManager.processArgs(argv);
       console.log.restore();
       expect(RdGlobalConfig.proxy.host).to.eql('host');

--- a/test/commandLine.test.js
+++ b/test/commandLine.test.js
@@ -31,11 +31,23 @@ describe('CommandLineManager', function () {
 
     it('parse proxy-host and proxy-port params', function () {
       sinon.stub(console, 'log');
-      argv = argv.concat(['--proxy-host', 'http://host', '--proxy-port', '9687']);
+      argv = argv.concat(['--proxy-host', 'host', '--proxy-port', '9687']);
       CommandLineManager.processArgs(argv);
       console.log.restore();
       expect(RdGlobalConfig.proxy.host).to.eql('host');
       expect(RdGlobalConfig.proxy.port).to.eql(9687);
+    });
+
+    it('remove any protocal part from proxy-host', function () {
+      sinon.stub(console, 'log');
+      argv = argv.concat(['--proxy-host', 'http://host']);
+      CommandLineManager.processArgs(argv);
+      expect(RdGlobalConfig.proxy.host).to.eql('host');
+
+      argv = argv.concat(['--proxy-host', '//host']);
+      CommandLineManager.processArgs(argv);
+      console.log.restore();
+      expect(RdGlobalConfig.proxy.host).to.eql('host');
     });
 
     it('proxy-port is set to the default value when its not in the expected range', function () {

--- a/test/commandLine.test.js
+++ b/test/commandLine.test.js
@@ -38,12 +38,14 @@ describe('CommandLineManager', function () {
       expect(RdGlobalConfig.proxy.port).to.eql(9687);
     });
 
-    it('remove any protocal part from proxy-host', function () {
+    it('remove any protocol part from proxy-host', function () {
       sinon.stub(console, 'log');
       argv = argv.concat(['--proxy-host', 'http://host']);
       CommandLineManager.processArgs(argv);
       expect(RdGlobalConfig.proxy.host).to.eql('host');
+    });
 
+    it('remove any prefix slashes from proxy-host', function () {
       argv = argv.concat(['--proxy-host', '//host']);
       CommandLineManager.processArgs(argv);
       console.log.restore();


### PR DESCRIPTION
JIRA Task: https://browserstack.atlassian.net/browse/ACE-1059

Remove any protocol (http / https) part from proxy host since Node's HTTP module doesn't handle it on its own while making any request. Thus, for any proxy which is not resolvable via DNS, it will fail if the input is of the format: `http://host:port`.